### PR TITLE
jetstack v1.3.0 -> cert-manager v1.7.0 move.

### DIFF
--- a/base/cert-manager.yaml
+++ b/base/cert-manager.yaml
@@ -1,7 +1,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1beta1
 kind: HelmRepository
 metadata:
-  name: jetstack
+  name: cert-manager
   namespace: flux-system
 spec:
   interval: 1m0s
@@ -16,10 +16,10 @@ spec:
   chart:
     spec:
       chart: cert-manager
-      version: v1.3.0
+      version: v1.7.0
       sourceRef:
         kind: HelmRepository
-        name: jetstack
+        name: cert-manager
         namespace: flux-system
   interval: 1m0s
   releaseName: cert-manager


### PR DESCRIPTION
This should fix #7.

Signed-off-by: Kurt Garloff <kurt@garloff.de>