### PR TITLE
Expose harbor metrics

### DIFF
--- a/envs/public/harbor-config.yaml
+++ b/envs/public/harbor-config.yaml
@@ -15,6 +15,8 @@ data:
       - database
     registry:
       replicas: 2
+    metrics:
+      enabled: true
     cache:
       enabled: true
     expose:


### PR DESCRIPTION
Metrics are exposed by several Harbor components: exporter, core, jobservice, and registry.

E.g. exporter metrics:
```
$ kubectl port-forward svc/harbor-harbor-exporter 8001
$ curl localhost:8001/metrics | grep harbor_health
# HELP harbor_health Running status of Harbor
# TYPE harbor_health gauge
harbor_health 1
```

See https://goharbor.io/docs/main/administration/metrics/ for more.

Fixes #29